### PR TITLE
Add Escola Secundária de Camões (alunos.escamoes.pt)

### DIFF
--- a/domains/escamoes/alunos.escamoes.pt
+++ b/domains/escamoes/alunos.escamoes.pt
@@ -1,0 +1,2 @@
+Escola secundária de camões
+Camões secondary school


### PR DESCRIPTION
Adds the domain alunos.escamoes.pt for Escola Secundária de Camões, an educational institution in Lisbon, Portugal, for eligibility for JetBrains educational licenses.