### PR TITLE
Add Escola Secundária de camões (alunos.escamoes.pt)

### DIFF
--- a/lib/domains/pt/alunos.txt
+++ b/lib/domains/pt/alunos.txt
@@ -1,0 +1,2 @@
+Escola secundária de camões
+Camões secondary school


### PR DESCRIPTION
Adds the domain alunos.escamoes.pt for Escola Secundária de camões, an educational institution in Lisbon, Portugal, for JetBrains educational license eligibility.
- Official website: https://liceucamoes.wixsite.com/camoes
- IT course: Técnico de Gestão e Programação de Sistemas Informáticos (vocational course in IT management and programming, duration: 3 years)
- Proof of domain: I am a student at this school, and the domain alunos.escamoes.pt is provided to students for institutional emails (e.g., 520481@alunos.escamoes.pt).